### PR TITLE
Moved dart board, add 701, 501, 301 to 0, and around the world, with …

### DIFF
--- a/Bang!/Models/FinalSaloon/day_5._finalthe_western_saloon.glb.import
+++ b/Bang!/Models/FinalSaloon/day_5._finalthe_western_saloon.glb.import
@@ -29,6 +29,12 @@ animation/fps=30
 animation/trimming=false
 animation/remove_immutable_tracks=true
 import_script/path=""
-_subresources={}
+_subresources={
+"nodes": {
+"PATH:Sketchfab_model/the western saloon1_fbx/RootNode/Plane_232": {
+"import/skip_import": true
+}
+}
+}
 gltf/naming_version=1
 gltf/embedded_image_handling=1

--- a/Bang!/Scenes/world.tscn
+++ b/Bang!/Scenes/world.tscn
@@ -24,7 +24,7 @@ glow_enabled = true
 transform = Transform3D(1, -1.49012e-08, -1.49012e-08, -1.49012e-08, 1, -2.98023e-08, -1.49012e-08, 0, 1, 1.19209e-07, -4.76837e-07, -2.38419e-07)
 
 [node name="DartGame" parent="Stage" node_paths=PackedStringArray("player") instance=ExtResource("2_eoq0f")]
-transform = Transform3D(0.03, 0, 8.21504e-18, -1.33227e-17, -1.31134e-09, -0.03, 0, 0.03, -1.31134e-09, 3.50263, 1.8, 5)
+transform = Transform3D(-0.0194834, 0.0228122, -9.97152e-10, 0, -1.31134e-09, -0.03, -0.0228122, -0.0194834, 8.51648e-10, -4.752, 1.8, 14.355)
 player = NodePath("../../Player")
 
 [node name="ShooterBox" parent="Stage" node_paths=PackedStringArray("player", "camera") instance=ExtResource("2_nnvxg")]
@@ -34,7 +34,6 @@ camera = NodePath("../../Player/Head/Camera3D")
 metadata/_edit_lock_ = true
 
 [node name="Final_Saloon" parent="Stage" instance=ExtResource("4_1kixx")]
-metadata/_edit_lock_ = true
 
 [node name="Environment" type="Node3D" parent="."]
 

--- a/Bang!/Systems/DartGame/DartGame.tscn
+++ b/Bang!/Systems/DartGame/DartGame.tscn
@@ -51,22 +51,105 @@ shape = SubResource("CylinderShape3D_5tglm")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.198, 1.01375, -20.1322)
 metadata/_edit_lock_ = true
 
-[node name="TotalScoreLabel" type="Label3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 96, 7.10543e-14, -22)
+[node name="PerfectWinTimer" type="Timer" parent="."]
+
+[node name="SelectionLabels" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 42.9585, -1.87306e-06, -82.8506)
 visible = false
-text = "SCORE: 501"
+metadata/_edit_lock_ = true
+
+[node name="ModeSelectionLabel" type="Label3D" parent="SelectionLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0)
+text = "Select a Mode:
+"
 font = ExtResource("5_a10wp")
 font_size = 2000
 outline_size = 127
 horizontal_alignment = 2
+metadata/_edit_lock_ = true
 
-[node name="RoundScores" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 96, -2.18557e-07, -18)
+[node name="ModeLabel1" type="Label3D" parent="SelectionLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 10)
+text = "1.    701 to 0"
+font = ExtResource("5_a10wp")
+font_size = 2000
+outline_size = 127
+horizontal_alignment = 2
+metadata/_edit_lock_ = true
+
+[node name="ModeLabel2" type="Label3D" parent="SelectionLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 20)
+text = "2.    501 to 0"
+font = ExtResource("5_a10wp")
+font_size = 2000
+outline_size = 127
+horizontal_alignment = 2
+metadata/_edit_lock_ = true
+
+[node name="ModeLabel3" type="Label3D" parent="SelectionLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 30)
+text = "3.    301 to 0"
+font = ExtResource("5_a10wp")
+font_size = 2000
+outline_size = 127
+horizontal_alignment = 2
+metadata/_edit_lock_ = true
+
+[node name="ModeLabel4" type="Label3D" parent="SelectionLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 7.4607e-14, 40)
+text = "4.Around World
+"
+font = ExtResource("5_a10wp")
+font_size = 2000
+outline_size = 127
+horizontal_alignment = 2
+metadata/_edit_lock_ = true
+
+[node name="GameLabels" type="Node3D" parent="."]
 visible = false
 
-[connection signal="focused" from="StartEndInteractable" to="." method="_on_interactable_focused"]
+[node name="TotalDartsLabel" type="Label3D" parent="GameLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 65.5, -4.26326e-14, -40)
+text = "DARTS:"
+font = ExtResource("5_a10wp")
+font_size = 2000
+outline_size = 127
+horizontal_alignment = 2
+metadata/_edit_lock_ = true
+
+[node name="DartsCountLabel" type="Label3D" parent="GameLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 90, -4.26326e-14, -40)
+text = "0"
+font = ExtResource("5_a10wp")
+font_size = 2000
+outline_size = 127
+horizontal_alignment = 2
+metadata/_edit_lock_ = true
+
+[node name="TotalScoreLabel" type="Label3D" parent="GameLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 65.5, 1.84741e-13, -22)
+text = "SCORE:"
+font = ExtResource("5_a10wp")
+font_size = 2000
+outline_size = 127
+horizontal_alignment = 2
+metadata/_edit_lock_ = true
+
+[node name="ScoreCountLabel" type="Label3D" parent="GameLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 90, 2.98428e-13, -22)
+text = "501"
+font = ExtResource("5_a10wp")
+font_size = 2000
+outline_size = 127
+horizontal_alignment = 2
+metadata/_edit_lock_ = true
+
+[node name="RoundScores" type="Node3D" parent="GameLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 90, 1.27898e-13, -20.5)
+metadata/_edit_lock_ = true
+
 [connection signal="interacted" from="StartEndInteractable" to="." method="_on_interactable_interacted"]
-[connection signal="unfocused" from="StartEndInteractable" to="." method="_on_interactable_unfocused"]
 [connection signal="body_entered" from="GameBoardShape" to="." method="_on_game_board_shape_body_entered"]
+[connection signal="timeout" from="PerfectWinTimer" to="." method="_on_perfect_win_timer_timeout"]
 
 [editable path="StartEndInteractable"]


### PR DESCRIPTION
- Moved dart board next to saloon doors (Removed cow hide to position it)
- Added multiple game functionality
- Added 701, 501, and 301 to 0 game modes (must end on double or bullseye to win, cannot get to 1 score remaining exactly)
- Added "Around the World/Clock" game mode (must score 1, then 2, then 3, up to 20, ending on 20)
- Added perfect games, showing rainbow color text when the player achieves this (701 = 12 darts, 501 = 9 darts, 301 = 6 darts, Around the World = 20)